### PR TITLE
add_file/ sanitise fix

### DIFF
--- a/perl_lib/EPrints/System.pm
+++ b/perl_lib/EPrints/System.pm
@@ -553,7 +553,7 @@ sub sanitise
 	# There are sample substitutions in the optional_filename_sanitise.pl file in the repo config
 
 	my $repo = EPrints->new->current_repository;
-	if ( $repo->can_call( "optional_filename_sanitise" ) )
+	if (defined $repo && $repo->can_call( "optional_filename_sanitise" ) )
 	{
 		$filepath = $repo->call( "optional_filename_sanitise", $repo, $filepath );
 	}


### PR DESCRIPTION
I have added a small fix that allows using System's add_file method in scripts (eg the Ethos downloader http://files.eprints.org/778/).

This error comes up when the subroutine is called outside of Apache (eg. from the CLI).

The issue was already noticed here:
eprints/eprints@69f4c9e