### PR TITLE
Quash undef error when not using load_defaultcfg

### DIFF
--- a/perl_lib/EPrints/Config.pm
+++ b/perl_lib/EPrints/Config.pm
@@ -256,7 +256,7 @@ sub load_repository_config_module
 
 	foreach my $dir ( $libcfgd, $defaultcfg_cfgd, $site_lib_cfgd, $repcfgd )
 	{
-		next if( ! -e $dir );
+		next if( !defined $dir || ! -e $dir );
 		opendir( my $dh, $dir ) || EPrints::abort( "Can't read cfg.d config files from $dir: $!" );
 		while( my $file = readdir( $dh ) )
 		{


### PR DESCRIPTION
Prevent this:
`Use of uninitialized value $dir in -e at /usr/share/eprints-ulcc/bin/../perl_lib/EPrints/Config.pm line 259` 
when not using `load_defaultcfg` in EPrints::SystemSettings