### PR TITLE
OAI 'Identify' - earliest datestamp

### DIFF
--- a/cgi/oai2
+++ b/cgi/oai2
@@ -417,7 +417,7 @@ sub Identify
 	);
 	$searchexp->add_field(
 		$dataset->field( "eprint_status" ),
-		"archive",
+		"archive deletion",
 		"EQ",
 		"ANY"
 	);


### PR DESCRIPTION
The Identify response has an 'earliest datestamp'. There could be a deleted record that is earlier than any (currently) live records.
This change will make sure an accurate `earliestDatestamp` is represented, meaning the OAI-PMH validator will be happy.